### PR TITLE
Update GCL wiki link

### DIFF
--- a/Resources.txt
+++ b/Resources.txt
@@ -4,7 +4,7 @@ Discord Server: https://discord.gg/prUAgd5
 Resources Server: https://discord.gg/5KzwJws
 Decompilation of Pokemon Diamond: https://github.com/martmists/pokediamond
 Cut content: https://tcrf.net/Pok%C3%A9mon_Diamond_and_Pearl
-GLC Forum: https://www.glitchcity.info/wiki/Category:Generation_IV_glitches
+GCL Wiki: https://glitchcity.wiki/wiki/Category:Generation_IV_glitches
 Routes: https://discord.gg/PEb5rcR
 Pokemon DP Scripts: https://whoturgled.com/dp_scripts.html
 


### PR DESCRIPTION
so it leads to a kept-alive version instead of an old text-only archive
also fix the typo as it drives me insane